### PR TITLE
Make the way exported symbols are specified configurable

### DIFF
--- a/docs/linuxdoc-howto/all-in-a-tumble.c
+++ b/docs/linuxdoc-howto/all-in-a-tumble.c
@@ -29,6 +29,28 @@ user_function(int a, ...)
 }
 /* parse-SNAP: */
 
+
+/* parse-SNIP: user_function */
+/**
+ * user_sum() - another function that can only be called in user context
+ * @a: first argument
+ * @b: second argument
+ *
+ * This function makes no sense, it's only a kernel-doc demonstration.
+ *
+ * Example:
+ * x = user_sum(1, 2);
+ *
+ * Return:
+ * Returns the sum of the @a and @b
+ */
+API_EXPORTED
+int user_sum(int a, int b)
+{
+  return b;
+}
+/* parse-SNAP: */
+
 /* parse-SNIP: internal_function */
 /**
  * internal_function - the answer

--- a/docs/linuxdoc-howto/all-in-a-tumble.h
+++ b/docs/linuxdoc-howto/all-in-a-tumble.h
@@ -18,6 +18,8 @@
 
 EXPORT_SYMBOL_GPL_FUTURE(user_function)
 
+int user_sum(int a, int b);
+
 /**
  * block_touch_buffer - mark a buffer accessed
  * @bh: buffer_head being touched

--- a/docs/linuxdoc-howto/kernel-doc-directive.rst
+++ b/docs/linuxdoc-howto/kernel-doc-directive.rst
@@ -41,6 +41,8 @@ Here is a short overview of the options:
         :no-header:
         :export:
         :internal:
+        :exp-method: <method>
+        :exp-ids:    <identifier [, identifiers [, ...]]>
         :functions: <function [, functions [, ...]]>
         :module:    <prefix-id>
         :man-sect:  <man sect-no>
@@ -81,6 +83,29 @@ these options make sense:
     Include documentation for all documented definitions, **not** exported using
     EXPORT_SYMBOL macro either in ``<src-filename>`` or in any of the files
     specified by ``<src-fname-pattern>``.
+
+``exp-method <method>``
+    Change the way exported symbols are specified in source code.
+    Default value ('macro') if not provided can be set globally by
+    kernel_doc_exp_method in the sphinx configuration.
+    ``<method>`` must one of the following value:
+
+    ``macro``
+        Exported symbols are specified by macros (whose names are
+        controlled by ```exp-ids` option) invoked in the source the
+        following way: THIS_IS_AN_EXPORTED_SYMBOL(symbol)
+
+    ``attribute``
+        Exported symbols are specified definition using a specific
+        attribute (controlled by ```exp-ids` option) either in their
+        declaration or definition:
+        THIS_IS_AN_EXPORTED_SYMBOL int symbol(void* some_arg) {...}
+
+``exp-ids <identifier [, identifiers [, ...]]>``
+    Use the specified list of identifiers instead of default value:
+    EXPORT_SYMBOL, EXPORT_SYMBOL_GPL, EXPORT_SYMBOL_GPL_FUTURE. Default
+    value can be overriden globally by sphinx configuration option:
+    kernel_doc_exp_ids
 
 ``functions <name [, names [, ...]]>``
     Include documentation for each named definition.

--- a/docs/linuxdoc-howto/kernel-doc-directive.rst
+++ b/docs/linuxdoc-howto/kernel-doc-directive.rst
@@ -107,6 +107,14 @@ these options make sense:
     value can be overriden globally by sphinx configuration option:
     kernel_doc_exp_ids
 
+``known-attrs <attr [, attrs [, ...]]>``
+    Specified a list of function attribute that are known and must be
+    hidden when displaying function prototype. When ``exp-method`` is
+    set to 'attribute' the list in ``exp-ids`` is considered as known
+    and added implicitely to this list of known attributes. The default
+    list is empty and can be adjusted by the sphinx configuration option
+    kernel_doc_known_attrs
+
 ``functions <name [, names [, ...]]>``
     Include documentation for each named definition.
 

--- a/docs/linuxdoc-howto/kernel-doc-tests.rst
+++ b/docs/linuxdoc-howto/kernel-doc-tests.rst
@@ -74,6 +74,33 @@ and parses comments from ``all-in-a-tumble.c``.
         :man-sect: 2
 
 
+This test gathers function ``all-in-a-tumble.c`` whose function attributes
+mark them as exported and that are present in ``all-in-a-tumble.h``.
+
+.. code-block:: rst
+
+    .. kernel-doc::  ./all-in-a-tumble.c
+        :export:  ./all-in-a-tumble.h
+        :exp-method: attribute
+        :exp-ids: API_EXPORTED
+        :module: test-example-fnattrs
+        :man-sect: 2
+
+.. admonition:: exported symbols
+    :class: rst-example
+
+    .. kernel-doc::  ./all-in-a-tumble.c
+        :export:  ./all-in-a-tumble.h
+        :exp-method: attribute
+        :exp-ids: API_EXPORTED
+        :module: test-example-fnattrs
+        :man-sect: 2
+
+The ``exp-method`` and ``exp-ids`` could be respectively omitted if
+``kernel_doc_exp_method`` and ``kernel_doc_exp_ids`` are set in the sphinx
+configuration.
+
+
 Get documentation of internal symbols
 -------------------------------------
 

--- a/linuxdoc/autodoc.py
+++ b/linuxdoc/autodoc.py
@@ -32,7 +32,7 @@ import multiprocessing
 
 import six
 
-from fspath import FSPath
+import os
 from . import kernel_doc as kerneldoc
 from .kernel_doc import Container
 
@@ -78,12 +78,12 @@ def main():
     CLI.add_argument(
         "srctree"
         , help    = "Folder of source code."
-        , type    = lambda x: FSPath(x).ABSPATH)
+        , type    = lambda x: os.path.abspath(x))
 
     CLI.add_argument(
         "doctree"
         , help    = "Folder to place reST documentation."
-        , type    = lambda x: FSPath(x).ABSPATH)
+        , type    = lambda x: os.path.abspath(x))
 
     CLI.add_argument(
         "--sloppy"
@@ -111,7 +111,7 @@ def main():
 
     CLI.add_argument(
         "--rst-files"
-        , type    = lambda x: FSPath(x).ABSPATH
+        , type    = lambda x: os.path.abspath(x)
         , help    = (
             "File that list source files, which has comments in reST markup."
             " Use kernel-grepdoc command to generate those file."))

--- a/linuxdoc/grep_doc.py
+++ b/linuxdoc/grep_doc.py
@@ -22,7 +22,7 @@ u"""
 # ------------------------------------------------------------------------------
 
 import argparse, re, sys
-from fspath import FSPath
+import os
 
 description = """ The 'kernel-grepdoc' command scans ``*.rst`` files from kernel's
 ``./Documentation`` source tree and filters all 'kernel-doc' directives.  The
@@ -52,7 +52,7 @@ def main():
     CLI.add_argument(
         "srctree"
         , help    = "Linux's source tree"
-        , type    = lambda x: FSPath(x).ABSPATH)
+        , type    = lambda x: os.path.abspath(x))
 
     CMD = CLI.parse_args()
 

--- a/linuxdoc/kernel_doc.py
+++ b/linuxdoc/kernel_doc.py
@@ -69,8 +69,6 @@ import textwrap
 
 import six
 
-from fspath import OS_ENV
-
 # ==============================================================================
 # common globals
 # ==============================================================================
@@ -338,9 +336,9 @@ class DevNull(object):
         pass
 DevNull = DevNull()
 
-KBUILD_VERBOSE = int(OS_ENV.get("KBUILD_VERBOSE", "0"))
-KERNELVERSION  = OS_ENV.get("KERNELVERSION", "unknown kernel version")
-SRCTREE        = OS_ENV.get("srctree", "")
+KBUILD_VERBOSE = int(os.getenv("KBUILD_VERBOSE", "0"))
+KERNELVERSION  = os.getenv("KERNELVERSION", "unknown kernel version")
+SRCTREE        = os.getenv("srctree", "")
 GIT_REF        = ("Linux kernel source tree:"
                   " `%(rel_fname)s <https://git.kernel.org/cgit/linux/kernel/git/torvalds/linux.git/tree/"
                   "%(rel_fname)s>`__")

--- a/linuxdoc/kernel_doc.py
+++ b/linuxdoc/kernel_doc.py
@@ -465,7 +465,7 @@ def main():
     CLI.add_argument(
         "--list-exports"
         , action  = "store_true"
-        , help    = "list all symbols exported using EXPORT_SYMBOL" )
+        , help    = "list all exported symbols" )
 
     CLI.add_argument(
         "--use-names"
@@ -475,8 +475,7 @@ def main():
     CLI.add_argument(
         "--exported"
         , action  = "store_true"
-        , help    = ("print documentation of all symbols exported"
-                     " using EXPORT_SYMBOL macros" ))
+        , help    = "print documentation of all exported symbols")
 
     CLI.add_argument(
          "--internal"
@@ -491,6 +490,19 @@ def main():
         , help    = (
             "Markup of the comments. Change this option only if you know"
             " what you do. New comments must be marked up with reST!"))
+
+    CLI.add_argument(
+        "--symbols-exported-method"
+        , default = DEFAULT_EXP_METHOD
+        , help    = (
+            "Indicate the way by which an exported symbol an exported symbol"
+            " is exported. Must be either 'macro' or 'attribute'."))
+
+    CLI.add_argument(
+        "--symbols-exported-identifiers"
+        , nargs   = "+"
+        , default = DEFAULT_EXP_IDS
+        , help    = "identifiers list that specifies an exported symbol")
 
     CMD     = CLI.parse_args()
     VERBOSE = CMD.verbose
@@ -513,6 +525,8 @@ def main():
             , out           = STREAM.appl_out
             , markup        = CMD.markup
             , verbose_warn  = not (CMD.sloppy)
+            , exp_method    = CMD.symbols_exported_method
+            , exp_ids       = CMD.symbols_exported_identifiers
             ,)
         opts.set_defaults()
 

--- a/linuxdoc/kernel_doc.py
+++ b/linuxdoc/kernel_doc.py
@@ -227,7 +227,7 @@ FUNC_PROTOTYPES = [
 ]
 
 EXPORTED_SYMBOLS = RE(
-    r"^\s*(EXPORT_SYMBOL)(_GPL)?(_FUTURE)?\s*\(\s*(\w*)\s*\)\s*", flags=re.M)
+    r"^\s*(?:(?:EXPORT_SYMBOL)|(?:EXPORT_SYMBOL_GPL)|(?:EXPORT_SYMBOL_GPL_FUTURE))\s*\(\s*(\w*)\s*\)\s*", flags=re.M)
 
 # MODULE_AUTHOR("..."); /  MODULE_DESCRIPTION("..."); / MODULE_LICENSE("...");
 #
@@ -1676,8 +1676,7 @@ class Parser(SimpleLog):
         """
 
         LOG.debug("gather_context() regExp: %(pattern)s", pattern=EXPORTED_SYMBOLS.pattern)
-        for match in EXPORTED_SYMBOLS.findall(src):
-            name = match[3]
+        for name in EXPORTED_SYMBOLS.findall(src):
             LOG.info("exported symbol: %(name)s", name = name)
             ctx.exported_symbols.append(name)
 

--- a/linuxdoc/kernel_doc.py
+++ b/linuxdoc/kernel_doc.py
@@ -504,6 +504,13 @@ def main():
         , default = DEFAULT_EXP_IDS
         , help    = "identifiers list that specifies an exported symbol")
 
+    CLI.add_argument(
+        "--known-attrs"
+        , default = ""
+        , nargs   = "+"
+        , help    = ("provides a list of known attributes that has to be"
+                     " hidden when displaying function prototypes"))
+
     CMD     = CLI.parse_args()
     VERBOSE = CMD.verbose
     DEBUG   = CMD.debug
@@ -527,6 +534,7 @@ def main():
             , verbose_warn  = not (CMD.sloppy)
             , exp_method    = CMD.symbols_exported_method
             , exp_ids       = CMD.symbols_exported_identifiers
+            , known_attrs   = CMD.known_attrs
             ,)
         opts.set_defaults()
 
@@ -1330,6 +1338,7 @@ class ParseOptions(Container):
         self.gather_context    = False
         self.exp_method        = None
         self.exp_ids           = []
+        self.known_attrs       = []
 
         # epilog / preamble
 
@@ -2418,7 +2427,7 @@ class Parser(SimpleLog):
         proto = re.sub( r"__weak +"          , "", proto )
 
         # Remove known attributes from function prototype
-        known_attrs = []
+        known_attrs = self.options.known_attrs
         if (self.options.exp_method == 'attribute'):
             known_attrs.extend(self.options.exp_ids)
         for attr in known_attrs:

--- a/linuxdoc/lint.py
+++ b/linuxdoc/lint.py
@@ -31,7 +31,7 @@ import argparse
 
 #import six
 
-from fspath import FSPath
+import os
 from . import kernel_doc as kerneldoc
 
 # ------------------------------------------------------------------------------
@@ -58,7 +58,7 @@ def main():
     CLI.add_argument(
         "srctree"
         , help    = "File or folder of source code."
-        , type    = lambda x: FSPath(x).ABSPATH)
+        , type    = lambda x: os.path.abspath(x))
 
     CLI.add_argument(
         "--sloppy"

--- a/linuxdoc/rstKernelDoc.py
+++ b/linuxdoc/rstKernelDoc.py
@@ -24,6 +24,7 @@ u"""
             :internal:
             :exp-method:  <method>
             :exp-ids:     <identifier [, identifiers [, ...]]>
+            :known-attrs: <attr [, attrs [, ...]]>
             :functions: <function [, functions [, ...]]>
             :module:    <prefix-id>
             :man-sect:  <man sect-no>
@@ -87,6 +88,14 @@ u"""
         EXPORT_SYMBOL, EXPORT_SYMBOL_GPL, EXPORT_SYMBOL_GPL_FUTURE. Default
         value can be overriden globally by sphinx configuration option:
         kernel_doc_exp_ids
+
+    ``known-attrs <attr [, attrs [, ...]]>``
+        Specified a list of function attribute that are known and must be
+        hidden when displaying function prototype. When ``exp-method`` is
+        set to 'attribute' the list in ``exp-ids`` is considered as known
+        and added implicitely to this list of known attributes. The default
+        list is empty and can be adjusted by the sphinx configuration option
+        kernel_doc_known_attrs
 
     ``functions <name [, names [, ...]]>``
         Include documentation for each named definition.
@@ -221,6 +230,7 @@ def setup(app):
     app.add_config_value('kernel_doc_mansect', None, 'env')
     app.add_config_value('kernel_doc_exp_method', None, 'env')
     app.add_config_value('kernel_doc_exp_ids', None, 'env')
+    app.add_config_value('kernel_doc_known_attrs', None, 'env')
     app.add_directive("kernel-doc", KernelDoc)
 
     return dict(
@@ -292,6 +302,7 @@ class KernelDoc(Directive):
         , "functions"  : directives.unchanged_required # aka lines containing !F
         , "exp-method" : directives.unchanged_required
         , "exp-ids"    : directives.unchanged_required
+        , "known-attrs": directives.unchanged_required
 
         , "debug"      : directives.flag               # insert generated reST as code-block
 
@@ -317,6 +328,7 @@ class KernelDoc(Directive):
         exp_files = []  # file pattern to search for EXPORT_SYMBOL
         exp_method  = self.options.get("exp-method", self.env.config.kernel_doc_exp_method)
         exp_ids     = self.options.get("exp-ids", self.env.config.kernel_doc_exp_ids)
+        known_attrs = self.options.get("known-attrs", self.env.config.kernel_doc_known_attrs)
 
         if self.arguments[0].startswith("./"):
             # the prefix "./" indicates a relative pathname
@@ -352,6 +364,7 @@ class KernelDoc(Directive):
             , man_sect      = self.options.get("man-sect", None)
             , exp_method    = exp_method
             , exp_ids       = (exp_ids or "").replace(","," ").split()
+            , known_attrs   = (known_attrs or "").replace(","," ").split()
             ,)
 
         if ("doc" not in self.options

--- a/linuxdoc/rstKernelDoc.py
+++ b/linuxdoc/rstKernelDoc.py
@@ -22,6 +22,8 @@ u"""
             :no-header:
             :export:
             :internal:
+            :exp-method:  <method>
+            :exp-ids:     <identifier [, identifiers [, ...]]>
             :functions: <function [, functions [, ...]]>
             :module:    <prefix-id>
             :man-sect:  <man sect-no>
@@ -62,6 +64,29 @@ u"""
         Include documentation for all documented definitions, **not** exported using
         EXPORT_SYMBOL macro either in ``<src-filename>`` or in any of the files
         specified by ``<src-fname-pattern>``.
+
+    ``exp-method <method>``
+        Change the way exported symbols are specified in source code.
+        Default value ('macro') if not provided can be set globally by
+        kernel_doc_exp_method in the sphinx configuration.
+	``<method>`` must one of the following value:
+
+        ``macro``
+            Exported symbols are specified by macros (whose names are
+            controlled by ```exp-ids` option) invoked in the source the
+            following way: THIS_IS_AN_EXPORTED_SYMBOL(symbol)
+
+        ``attribute``
+            Exported symbols are specified definition using a specific
+            attribute (controlled by ```exp-ids` option) either in their
+            declaration or definition:
+            THIS_IS_AN_EXPORTED_SYMBOL int symbol(void* some_arg) {...}
+
+    ``exp-ids <identifier [, identifiers [, ...]]>``
+        Use the specified list of identifiers instead of default value:
+        EXPORT_SYMBOL, EXPORT_SYMBOL_GPL, EXPORT_SYMBOL_GPL_FUTURE. Default
+        value can be overriden globally by sphinx configuration option:
+        kernel_doc_exp_ids
 
     ``functions <name [, names [, ...]]>``
         Include documentation for each named definition.
@@ -194,6 +219,8 @@ def setup(app):
     app.add_config_value('kernel_doc_verbose_warn', True, 'env')
     app.add_config_value('kernel_doc_mode', "reST", 'env')
     app.add_config_value('kernel_doc_mansect', None, 'env')
+    app.add_config_value('kernel_doc_exp_method', None, 'env')
+    app.add_config_value('kernel_doc_exp_ids', None, 'env')
     app.add_directive("kernel-doc", KernelDoc)
 
     return dict(
@@ -263,6 +290,8 @@ class KernelDoc(Directive):
         , "export"     : directives.unchanged          # aka lines containing !E
         , "internal"   : directives.unchanged          # aka lines containing !I
         , "functions"  : directives.unchanged_required # aka lines containing !F
+        , "exp-method" : directives.unchanged_required
+        , "exp-ids"    : directives.unchanged_required
 
         , "debug"      : directives.flag               # insert generated reST as code-block
 
@@ -286,6 +315,8 @@ class KernelDoc(Directive):
         fname     = self.arguments[0]
         src_tree  = kerneldoc.SRCTREE
         exp_files = []  # file pattern to search for EXPORT_SYMBOL
+        exp_method  = self.options.get("exp-method", self.env.config.kernel_doc_exp_method)
+        exp_ids     = self.options.get("exp-ids", self.env.config.kernel_doc_exp_ids)
 
         if self.arguments[0].startswith("./"):
             # the prefix "./" indicates a relative pathname
@@ -319,6 +350,8 @@ class KernelDoc(Directive):
             , verbose_warn  = self.env.config.kernel_doc_verbose_warn
             , markup        = self.env.config.kernel_doc_mode
             , man_sect      = self.options.get("man-sect", None)
+            , exp_method    = exp_method
+            , exp_ids       = (exp_ids or "").replace(","," ").split()
             ,)
 
         if ("doc" not in self.options

--- a/linuxdoc/rstKernelDoc.py
+++ b/linuxdoc/rstKernelDoc.py
@@ -350,13 +350,13 @@ class KernelDoc(Directive):
 
         if "export" in self.options:
             # gather exported symbols and add them to the list of names
-            kerneldoc.Parser.gather_context(kerneldoc.readFile(opts.fname), ctx)
+            kerneldoc.Parser.gather_context(kerneldoc.readFile(opts.fname), ctx, opts)
             exp_files.extend((self.options.get('export') or "").replace(","," ").split())
             opts.error_missing = True
 
         elif "internal" in self.options:
             # gather exported symbols and add them to the ignore-list of names
-            kerneldoc.Parser.gather_context(kerneldoc.readFile(opts.fname), ctx)
+            kerneldoc.Parser.gather_context(kerneldoc.readFile(opts.fname), ctx, opts)
             exp_files.extend((self.options.get('internal') or "").replace(","," ").split())
 
         if "functions" in self.options:
@@ -380,7 +380,7 @@ class KernelDoc(Directive):
 
             for fname in glob.glob(pattern):
                 self.env.note_dependency(path.abspath(fname))
-                kerneldoc.Parser.gather_context(kerneldoc.readFile(fname), ctx)
+                kerneldoc.Parser.gather_context(kerneldoc.readFile(fname), ctx, opts)
 
         if "export" in self.options:
             if not ctx.exported_symbols:

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,8 +2,6 @@
 # requires
 # --------
 
-fspath
-
 # --------------
 # tests_requires
 # --------------

--- a/setup.py
+++ b/setup.py
@@ -6,8 +6,7 @@
 from setuptools import setup, find_packages
 import linuxdoc
 
-install_requires = [
-    'fspath' ]
+install_requires = []
 
 setup(
     name               = "linuxdoc"


### PR DESCRIPTION
Projects different from Linux Kernel uses different means to specify exported symbol. Often it is done though a function attribute which will indicate if the linker must export or not the symbol in the shared library being built.

This set of patches allows to configure this either from commandline of kernel doc, either from kernel-doc sphinx directive, either from the sphinx configuration.