### PR TITLE
[kernel-doc] add the kernel_doc_srctree sphinx configuration

### DIFF
--- a/docs/linuxdoc-howto/kernel-doc-directive.rst
+++ b/docs/linuxdoc-howto/kernel-doc-directive.rst
@@ -60,9 +60,10 @@ Here is a short overview of the directives options:
 
 The argument ``<src-filename>`` is required and points to the source file.  The
 pathname is relative to the pathname of the ``kernel-doc`` directive.  Absolute
-pathnames are relative to environment ``srctree`` (if unset, defaults to CWD).
-The options have the following meaning, but be aware that not all combinations
-of these options make sense:
+pathnames are relative to ``srctree``, which can be set in the environment or
+using :ref:`kernel_doc_srctree <kernel-doc-config>` in the sphinx conf.py_ (if
+unset, defaults to CWD).  The options have the following meaning, but be aware
+that not all combinations of these options make sense:
 
 ``:doc: <section title>`` (:ref:`doc_sections`)
     Include content of the ``DOC:`` section titled ``<section title>``.  Spaces
@@ -431,4 +432,8 @@ kernel_doc_raise_error: ``True``
 
      .. kernel-doc::  ./all-in-a-tumble.h
         :symbols:  no_longer_exist
+
+kernel_doc_srctree: ``None``
+  Set the pathname used as a base for absolute pathnames in kernel-doc
+  directive.  It can be overridden by the ``srctree`` environment variable.
 

--- a/linuxdoc/rstKernelDoc.py
+++ b/linuxdoc/rstKernelDoc.py
@@ -29,6 +29,7 @@ from docutils.utils import SystemMessage
 from docutils.statemachine import ViewList
 from sphinx.util.docutils import switch_source_input
 
+from fspath import OS_ENV
 from . import kernel_doc as kerneldoc
 
 # ==============================================================================
@@ -52,6 +53,7 @@ def setup(app):
     app.add_config_value('kernel_doc_exp_method', None, 'env')
     app.add_config_value('kernel_doc_exp_ids', None, 'env')
     app.add_config_value('kernel_doc_known_attrs', None, 'env')
+    app.add_config_value('kernel_doc_srctree', kerneldoc.SRCTREE, 'env')
     app.add_directive("kernel-doc", KernelDoc)
 
     return dict(
@@ -160,9 +162,10 @@ class KernelDoc(Directive):
         known_attrs = self.options.get("known-attrs", self.env.config.kernel_doc_known_attrs)
 
         if self.arguments[0].startswith("/"):
-            # Absolute path names are relative to kerneldoc.SRCTREE
+            # Absolute path names are relative to srctree, which is taken from
+            # environment, configuration or current directory (in this order).
             fname = self.arguments[0][1:]
-            src_tree = kerneldoc.SRCTREE
+            src_tree = OS_ENV.get("srctree", self.env.config.kernel_doc_srctree)
 
         if "internal" in self.options and "export" in self.options:
             raise FaultyOption(


### PR DESCRIPTION
This has the same effect as setting the srctree environment variable.

This allows building a sphinx documentation without a specialized
Makefile.

It can still be overridden by environment.
