### PR TITLE
[kernel-doc] fix extra space on function typedef return type

### DIFF
--- a/linuxdoc/kernel_doc.py
+++ b/linuxdoc/kernel_doc.py
@@ -2789,7 +2789,7 @@ class Parser(SimpleLog):
         if matchExpr:
             # Parse function prototypes
 
-            self.ctx.return_type = matchExpr[0]
+            self.ctx.return_type = matchExpr[0].lstrip()
             self.ctx.decl_name   = matchExpr[1]
             self.check_return_section(self.ctx.decl_name, self.ctx.return_type)
 


### PR DESCRIPTION
The typedef return type regex matches the space between typedef and the
function return type. Drop those space.

This solves a wrong warning for this kind of definition:

    /**
     * typedef sum - Sum function pointer.
     * @a: The number A.
     * @b: The number B.
     */
    typedef void (*sum)(int a, int b);

Which gave:

    :WARN: no description found for return-value of function 'sum()'

Looking at kernel-doc original code, the regex is the same, but the
extra space is dropped:

    $return_type =~ s/^\s+//;

Signed-off-by: Nicolas Schodet <nico@ni.fr.eu.org>