### PR TITLE
Fix :widths: for flat-table

### DIFF
--- a/linuxdoc/rstFlatTable.py
+++ b/linuxdoc/rstFlatTable.py
@@ -138,9 +138,12 @@ class ListTableBuilder(object):
         header_rows  = self.directive.options.get('header-rows', 0)
 
         table = nodes.table()
+        if self.directive.widths == 'auto':
+            table['classes'] += ['colwidths-auto']
+        elif self.directive.widths:  # explicitly set column widths
+            table['classes'] += ['colwidths-given']
         tgroup = nodes.tgroup(cols=len(colwidths))
         table += tgroup
-
 
         for colwidth in colwidths:
             colspec = nodes.colspec(colwidth=colwidth)

--- a/linuxdoc/rstFlatTable.py
+++ b/linuxdoc/rstFlatTable.py
@@ -20,7 +20,7 @@ Implementation of the ``flat-table`` reST-directive.  User documentation see
 
 from docutils import nodes
 from docutils.parsers.rst import directives, roles
-from docutils.parsers.rst.directives.tables import Table
+from docutils.parsers.rst.directives.tables import Table, align
 from docutils.utils import SystemMessagePropagation
 
 # ==============================================================================
@@ -87,8 +87,11 @@ class FlatTable(Table):
         , 'class': directives.class_option
         , 'header-rows': directives.nonnegative_int
         , 'stub-columns': directives.nonnegative_int
-        , 'widths': directives.positive_int_list
-        , 'fill-cells' : directives.flag }
+        , 'width': directives.length_or_percentage_or_unitless
+        , 'widths': directives.value_or(('auto', 'grid'), directives.positive_int_list)
+        , 'fill-cells': directives.flag
+        , 'align': align
+    }
 
     def run(self):
 
@@ -108,6 +111,9 @@ class FlatTable(Table):
         tableNode = tableBuilder.buildTableNode()
         self.add_name(tableNode)
         tableNode['classes'] += self.options.get('class', [])
+        self.set_table_width(tableNode)
+        if 'align' in self.options:
+            tableNode['align'] = self.options.get('align')
 
         # debug --> tableNode.asdom().toprettyxml()
         if title:

--- a/linuxdoc/rstFlatTable.py
+++ b/linuxdoc/rstFlatTable.py
@@ -135,11 +135,6 @@ class ListTableBuilder(object):
     def buildTableNode(self):
 
         colwidths    = self.directive.get_column_widths(self.max_cols)
-        if isinstance(colwidths, tuple):
-            # Since docutils 0.13, get_column_widths returns a (widths,
-            # colwidths) tuple, where widths is a string (i.e. 'auto').
-            # See https://sourceforge.net/p/docutils/patches/120/.
-            colwidths = colwidths[1]
         stub_columns = self.directive.options.get('stub-columns', 0)
         header_rows  = self.directive.options.get('header-rows', 0)
 


### PR DESCRIPTION
I noticed the :widths: attribute is ignored and I noticed it is because the created 'table' element is missing 'colwidths-given' class.