### PR TITLE
Same treatment for all function parameters

### DIFF
--- a/docs/linuxdoc-howto/all-in-a-tumble.h
+++ b/docs/linuxdoc-howto/all-in-a-tumble.h
@@ -26,6 +26,14 @@ int user_function(int a, ...)
 int user_sum(int a, int b);
 /* parse-SNAP: */
 
+/* parse-SNIP: function pointer argument */
+/**
+ * callback() - Callback function with a function pointer argument
+ * @fct_ptr: Function to call.
+ *
+ */
+void callback(void (*fct_ptr)(void *));
+/* parse-SNAP: */
 
 /**
  * block_touch_buffer - mark a buffer accessed
@@ -323,7 +331,7 @@ typedef int my_typedef;
  *      \|     \|      |/     |/
  *       +------+      +------+
  *        foo()         bar()
- * 
+ *
  * Highlighted code blocks:
  * The next example shows a code block, with highlighting C syntax in the
  * output.

--- a/linuxdoc/kernel_doc.py
+++ b/linuxdoc/kernel_doc.py
@@ -1097,14 +1097,7 @@ class ReSTTranslator(TranslatorAPI):
 
             param = ""
             param_type = None
-            if self.FUNC_PTR.search(p_type):
-                # pointer to function
-                param = ":param %s%s)(%s):" % (self.FUNC_PTR[0], p_name, self.FUNC_PTR[1])
-            elif p_type.endswith("*"):
-                # pointer & pointer to pointer
-                param = ":param %s:" % (p_name)
-                param_type = ":type %s: %s" % (p_name, p_type)
-            elif p_name == "...":
+            if p_name == "...":
                 param = ":param ellipsis ellipsis:"
             else:
                 param = ":param %s:" % (p_name.replace('_', r'\_'))


### PR DESCRIPTION
Previously function pointers where not output the way expected by sphinx and sphinx raise this error:
```
/workspace/doc/minimalist/source.c:3: WARNING: Unparseable C expression: 'void (*fct_ptr)(void'
Error when parsing (type) expression.
If expression:
  Invalid C declaration: Expected identifier in nested name, got keyword: void [error at 4]
    void (*fct_ptr)(void
    ----^
If type:
  Error in declarator
  If declarator-id with parameters:
    Invalid C declaration: Expected identifier in nested name. [error at 6]
      void (*fct_ptr)(void
      ------^
  If parenthesis in noptr-declarator:
    Invalid C declaration: Expected ')' in "( ptr-declarator )" [error at 7]
      void (*fct_ptr)(void
      -------^
```

Existing code treat differently the output dependening on parameter type, there is no reason.

Small example to generate error:
```c
/**
 * foo() - foo function.
 * @fct_ptr: Function to call.
 *
 */
void foo(void (*fct_ptr)(void *));
```

conf.py
```python
# -*- coding: utf-8 -*-
#
# Configuration file for the Sphinx documentation builder.
#
# This file does only contain a selection of the most common options. For a
# full list see the documentation:
# http://www.sphinx-doc.org/en/master/config

project = 'test'
author = 'test'

# Add any Sphinx extension module names here, as strings. They can be
# extensions coming with Sphinx (named 'sphinx.ext.*') or your custom
# ones.
extensions = [
    'linuxdoc.rstKernelDoc',
    'linuxdoc.cdomain',
]
```
index.rst
```rst
.. kernel-doc:: source.c
```
