### PR TITLE
[fix] add missing declaration type 'macro' to the parser

### DIFF
--- a/docs/linuxdoc-howto/all-in-a-tumble.h
+++ b/docs/linuxdoc-howto/all-in-a-tumble.h
@@ -516,3 +516,39 @@ typedef unsigned long (*genpool_algo_t)(unsigned long *map,
  * Returns true if the given timings are valid.
  */
 typedef bool v4l2_check_dv_timings_fnc(const struct v4l2_dv_timings *t, void *handle);
+
+
+/* parse-SNIP: ADD_macro */
+/**
+ * macro ADD - Function like macro to add two values
+ *
+ * @first:  first value
+ * @second:  second value
+ *
+ * Is replaced by a addition of @first and @second.
+ */
+#define ADD(first, second) (first) + (second)
+/* parse-SNAP: */
+
+/**
+ * iosys_map_wr_field - Write to a member of a struct in the iosys_map
+ *
+ * @map__:		The iosys_map structure
+ * @struct_offset__:	Offset from the beggining of the map, where the struct
+ *			is located
+ * @struct_type__:	The struct describing the layout of the mapping
+ * @field__:		Member of the struct to read
+ * @val__:		Value to write
+ *
+ * Write a value to the iosys_map considering its layout is described by a C
+ * struct starting at @struct_offset__. The field offset and size is calculated
+ * and the @val__ is written. If the field access would incur in un-aligned
+ * access, then either iosys_map_memcpy_to() needs to be used or the
+ * architecture must support it. Refer to iosys_map_rd_field() for expected
+ * usage and memory layout.
+ */
+#define iosys_map_wr_field(map__, struct_offset__, struct_type__, field__, val__) ({	\
+	struct_type__ *s;								\
+	iosys_map_wr(map__, struct_offset__ + offsetof(struct_type__, field__),		\
+		     typeof(s->field__), val__);					\
+})

--- a/docs/linuxdoc-howto/kernel-doc-syntax.rst
+++ b/docs/linuxdoc-howto/kernel-doc-syntax.rst
@@ -94,6 +94,20 @@ they are marked appropriately in the output format.
 
 Rendered example: :ref:`example.user_function`
 
+.. _kernel-doc-syntax-macro:
+
+macro
+=====
+
+Documenting macros is similar to documenting :ref:`kernel-doc-syntax-functions`.
+
+.. kernel-doc::  ./all-in-a-tumble.h
+    :snippets:  ADD_macro
+    :language:  c
+    :linenos:
+
+Rendered example: :ref:`example.ADD`
+
 .. _kernel-doc-syntax-structs-unions:
 
 structs, unions

--- a/linuxdoc/kernel_doc.py
+++ b/linuxdoc/kernel_doc.py
@@ -1104,8 +1104,9 @@ class ReSTTranslator(TranslatorAPI):
             elif p_name == "...":
                 param = ":param ellipsis ellipsis:"
             else:
-                param = ":param %s:" % (p_name)
-                param_type = ":type %s: %s" % (p_name, p_type)
+                param = ":param %s:" % (p_name.replace('_', r'\_'))
+                if p_type:
+                    param_type = ":type %s: %s" % (p_name.replace('_', r'\_'), p_type.replace('_', r'\_'))
 
             self.parser.ctx.offset = parameterdescs.offsets.get(
                 p_name, self.parser.ctx.offset)


### PR DESCRIPTION
Related: https://github.com/return42/linuxdoc/pull/20
Closes: https://github.com/return42/linuxdoc/issues/19