### PR TITLE
Fix multiline comments

### DIFF
--- a/docs/linuxdoc-howto/all-in-a-tumble.h
+++ b/docs/linuxdoc-howto/all-in-a-tumble.h
@@ -104,6 +104,7 @@ DEFINE_EVENT(block_buffer, block_dirty_buffer,
 /**
 * struct my_struct - a struct with nested unions and structs
 * @arg1: first argument of anonymous union/anonymous struct
+* lorem ipsum ...
 * @arg2: second argument of anonymous union/anonymous struct
 * @arg1b: first argument of anonymous union/anonymous struct
 * @arg2b: second argument of anonymous union/anonymous struct
@@ -173,11 +174,13 @@ struct my_struct {
 struct my_long_struct {
 	int foo;
         /**
-         * @bar: The Bar member.
+         * @bar: The Bar member,
+	 * lorem ipsum ..
          */
         int bar;
         /**
-         * @baz: The Baz member.
+         * @baz: The Baz member,
+	 * lorem ipsum ..
          *
          * Here, the member description may contain several paragraphs.
          */

--- a/linuxdoc/kernel_doc.py
+++ b/linuxdoc/kernel_doc.py
@@ -2205,7 +2205,7 @@ class Parser(SimpleLog):
 
             # First line (split_doc_state 1) needs to be a @parameter
             self.ctx.section  = self.sect_title(doc_state5_sect[0].strip())
-            self.ctx.contents = doc_state5_sect[1].strip()
+            self.ctx.contents = doc_state5_sect[1].strip() + "\n"
             self.split_doc_state = 2
             self.debug("SPLIT-DOC-START: '%(param)s' / split-state 1 --> 2"
                        , param = self.ctx.section)


### PR DESCRIPTION
Previously, when a multiline comment was parsed, the 2 first lines were combined

```c
/**                                                                        
 * struct foo - foo struct
 */                                                                        
struct foo {
    /**                                                                    
     * @page: bar is used by
     * foo struct
     */                                                                    
    int bar;
};                                                                         
```

results into a description `bar is used byfoo struct`, no blank between `by` and `foo`