### PR TITLE
Add Sphinx and docutils to the runtime dependencies

### DIFF
--- a/linuxdoc/__pkginfo__.py
+++ b/linuxdoc/__pkginfo__.py
@@ -89,8 +89,10 @@ py_modules = []
 # [dependency_links] https://python-packaging.readthedocs.io/en/latest/dependencies.html
 
 install_requires = [
+    'docutils',
     'fspath',
     'setuptools',
+    'sphinx',
 ]
 
 install_requires_txt = "\n".join(install_requires)

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,8 +3,10 @@
 # requirements of package linuxdoc
 # --------------------------------
 
+docutils
 fspath
 setuptools
+sphinx
 
 # test requires
 # -------------
@@ -15,7 +17,6 @@ pylint
 # -------
 
 twine
-Sphinx
 pallets-sphinx-themes
 sphinx-autobuild
 sphinx-issues


### PR DESCRIPTION
Both are imported throughout the package and appear to be required for basic functionality.