### PR TITLE
Update license info in docstrings

### DIFF
--- a/linuxdoc/__init__.py
+++ b/linuxdoc/__init__.py
@@ -7,7 +7,7 @@ extensions in common Sphinx-doc projects.
 
 :copyright:  Copyright (C) 2018 Markus Heiser
 :e-mail:     markus.heiser@darmarIT.de
-:license:    GPL Version 2, June 1991 see Linux/COPYING for details.
+:license:    AGPL-3.0-or-later; see LICENSE for details.
 :docs:       http://return42.github.io/linuxdoc
 :repository: `github return42/linuxdoc <https://github.com/return42/linuxdoc>`_
 """

--- a/linuxdoc/autodoc.py
+++ b/linuxdoc/autodoc.py
@@ -7,7 +7,7 @@ u"""
     Implementation of the ``kernel-autodoc`` command.
 
     :copyright:  Copyright (C) 2018 Markus Heiser
-    :license:    GPL Version 2, June 1991 see Linux/COPYING for details.
+    :license:    AGPL-3.0-or-later; see LICENSE for details.
 
     The ``kernel-autodoc`` command extracts documentation from Linux kernel's
     source code comments, see ``--help``::

--- a/linuxdoc/cdomainv3.py
+++ b/linuxdoc/cdomainv3.py
@@ -6,7 +6,7 @@ u"""
     Replacement for the sphinx c-domain.
 
     :copyright:  Copyright (C) 2020 Markus Heiser
-    :license:    GPL Version 2, June 1991 see Linux/COPYING for details.
+    :license:    AGPL-3.0-or-later; see LICENSE for details.
 
     For user documentation see :ref:`customized-c-domain`.
 """

--- a/linuxdoc/grep_doc.py
+++ b/linuxdoc/grep_doc.py
@@ -7,7 +7,7 @@ u"""
     Implementation of the ``kernel-grepdoc`` command.
 
     :copyright:  Copyright (C) 2018 Markus Heiser
-    :license:    GPL Version 2, June 1991 see Linux/COPYING for details.
+    :license:    AGPL-3.0-or-later; see LICENSE for details.
 
     The ``kernel-grepdoc`` command *greps* informations from Linux kernel's
     (reST) documentation, see ``--help``::

--- a/linuxdoc/kernel_include.py
+++ b/linuxdoc/kernel_include.py
@@ -7,7 +7,7 @@ u"""
     Implementation of the ``kernel-include`` reST-directive.
 
     :copyright:  Copyright (C) 2018 Markus Heiser
-    :license:    GPL Version 2, June 1991 see linux/COPYING for details.
+    :license:    AGPL-3.0-or-later; see LICENSE for details.
 
     For user documentation see :ref:`kernel-include-directive`.
 """

--- a/linuxdoc/lint.py
+++ b/linuxdoc/lint.py
@@ -7,7 +7,7 @@ u"""
     Implementation of the :ref:`kernel-lintdoc` command.
 
     :copyright:  Copyright (C) 2018  Markus Heiser
-    :license:    GPL Version 2, June 1991 see Linux/COPYING for details.
+    :license:    AGPL-3.0-or-later; see LICENSE for details.
 """
 
 # ------------------------------------------------------------------------------

--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -5,7 +5,7 @@
     ~~~~~~~~~~~~~~~~~~~~~~~~~
 
     :copyright:  Copyright (C) 2017 Markus Heiser
-    :license:    GPL Version 2, June 1991 see linux/COPYING for details.
+    :license:    AGPL-3.0-or-later; see LICENSE for details.
 """
 
 try:


### PR DESCRIPTION
Replace `GPL Version 2, June 1991 see linux/COPYING for details.` with `AGPL-3.0-or-later; see LICENSE for details.` in docstrings to reflect the new license.