### PR TITLE
Remove further unnecessary colSpan and rowSpan

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,5 +1,6 @@
 YYYY-MM-DD [YYYYMMDD]
 
+  [mod] remove further unnecessary colSpan and rowSpan (#35, #11)
   [mod] replace deprecated warn methods (#38)
   [mod] add mise.toml and a local develop environment in ./venv
   [fix] Replace parse_version() with parse() (#42)

--- a/docs/linuxdoc-howto/table-markup.rst
+++ b/docs/linuxdoc-howto/table-markup.rst
@@ -221,25 +221,6 @@ roles:
   :cspan: [int] additional columns (*morecols*)
   :rspan: [int] additional rows (*morerows*)
 
-  The ``:rspan:`` and ``:cspan:`` are *special* reST-roles_.  These directives
-  are used in the :py:obj:`linuxdoc.rstFlatTable.ListTableBuilder` and
-  :py:obj:`removed <linuxdoc.rstFlatTable.ListTableBuilder.parseCellItem>` while
-  the table is parsed.  These reST-roles must not be in the translation:
-
-  .. code-block:: po
-
-     #: ../index.rst:21
-     msgid ":rspan:`1` :cspan:`1` field 2.2 - 3.3"
-     msgstr "test (fr) field 2.2 - 3.3"
-
-  Most other reST-roles_ should be translated *as-is*:
-
-  .. code-block:: po
-
-     #: ../index.rst:48
-     msgid ":math:`a^2 + b^2 = c^2`"
-     msgstr "test (fr) :math:`a^2 + b^2 = c^2`"
-
 The example below shows how to use this markup.  The first level of the staged
 list is the *table-row*. In the *table-row* there is only one markup allowed,
 the list of the cells in this *table-row*. Exception are *comments* ( ``..`` )

--- a/linuxdoc/rstFlatTable.py
+++ b/linuxdoc/rstFlatTable.py
@@ -34,6 +34,7 @@ def setup(app):
     app.add_directive("flat-table", FlatTable)
     roles.register_local_role("cspan", c_span)
     roles.register_local_role("rspan", r_span)
+    app.connect("doctree-resolved", FlatTableProcessor)
 
     return dict(version=__version__, parallel_read_safe=True, parallel_write_safe=True)
 
@@ -336,3 +337,19 @@ class ListTableBuilder(object):
                 elem.parent.remove(elem)
                 continue
         return cspan, rspan, cellItem[:]
+
+
+class FlatTableProcessor:
+    """Remove colSpan and rowSpan from the document after the doctree-resolved
+    phase."""
+
+    # pylint: disable=unused-argument
+
+    def __init__(self, app, doctree: nodes.document, docname: str) -> None:
+        self.process(doctree)
+
+    def process(self, doctree: nodes.document) -> None:
+        for node in list(
+            doctree.findall(lambda item: isinstance(item, (colSpan, rowSpan)))
+        ):
+            node.parent.remove(node)


### PR DESCRIPTION
It is really annoying to have different text in the source language and in the translation.

This PR adds processor to the event `doctree-resolved` so all unnecessary nodes are removed there.

 - `cspan` and `rspan` are working as expected
 - internationalisation also works as expected, without the need to manually remove specific directives from translations

(inspired by the sphinx Todo extension)

Resolves #11