### PR TITLE
[fix]] kernel_include.py: cope with docutils 0.21

### DIFF
--- a/linuxdoc/kernel_include.py
+++ b/linuxdoc/kernel_include.py
@@ -76,10 +76,6 @@ class KernelInclude(Include):
             path = os.path.join(self.standard_include_path, path[1:-1])
         path = os.path.normpath(os.path.join(source_dir, path))
 
-        # HINT: this is the only line I had to change / commented out:
-        #path = utils.relative_path(None, path)
-
-        path = nodes.reprunicode(path)
         encoding = self.options.get(
             'encoding', self.state.document.settings.input_encoding)
         e_handler=self.state.document.settings.input_encoding_error_handler


### PR DESCRIPTION
Thie patch was copied from Linux kernel mailing list:

- https://lore.kernel.org/linux-doc/faf5fa45-2a9d-4573-9d2e-3930bdc1ed65@gmail.com/

----

docutils 0.21 has removed nodes.reprunicode, quote from release note [1]:

  * Removed objects:

    docutils.nodes.reprunicode, docutils.nodes.ensure_str() Python 2 compatibility hacks

Sphinx 7.3.0 supports docutils 0.21 [2]:

kernel_include.py, whose origin is misc.py of docutils, uses reprunicode.

Upstream docutils removed the offending line from the corresponding file (docutils/docutils/parsers/rst/directives/misc.py) in January 2022. Quoting the changelog [3]:

    Deprecate `nodes.reprunicode` and `nodes.ensure_str()`.

    Drop uses of the deprecated constructs (not required with Python 3).

Do the same for kernel_include.py.

Tested against:
  - Sphinx 2.4.5 (docutils 0.17.1)
  - Sphinx 3.4.3 (docutils 0.17.1)
  - Sphinx 5.3.0 (docutils 0.18.1)
  - Sphinx 6.2.1 (docutils 0.19)
  - Sphinx 7.2.6 (docutils 0.20.1)
  - Sphinx 7.3.7 (docutils 0.21.2)

[1] http://www.docutils.org/RELEASE-NOTES.html#release-0-21-2024-04-09
[2] https://www.sphinx-doc.org/en/master/changes.html#release-7-3-0-released-apr-16-2024
[3] https://github.com/docutils/docutils/commit/c8471ce47a24