### PR TITLE
[fix] export option to kernel-doc directive

### DIFF
--- a/linuxdoc/rstKernelDoc.py
+++ b/linuxdoc/rstKernelDoc.py
@@ -256,7 +256,7 @@ class KernelDoc(Directive):
             opts.no_header = bool("no-header" in self.options)
             opts.use_names.append(self.options.get("doc"))
 
-        if "export" in self.options and self.options.get('export'):
+        if "export" in self.options:
             kerneldoc.Parser.gather_context(kerneldoc.readFile(opts.fname), ctx, opts)
             exp_files.extend((self.options.get('export') or "").replace(","," ").split())
             opts.error_missing = True


### PR DESCRIPTION
When `export` option is provided to kernel-doc directive without option, the operation of collecting exported symbols by gather_context() is skipped and it will trigger error soon after because of missing exported symbols. It is however legitimate to use it without argument since in can be configured globally on project configuration.

This ensures that exported symbols are populated when `export` option is used in the directive no matter its value.